### PR TITLE
make plugin HTTP proxy request prefix-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Summary
 
-This _incomplete_ plugin is currently targeted to ArchivesSpace 2.x and when complete will implement
+This plugin is currently targeted at ArchivesSpace 2.x and implements
 Johns Hopkins University Sheridan Libraries branding-related customizations to the ArchivesSpace public
 user interface (PUI).
 
@@ -16,7 +16,6 @@ user interface (PUI).
     - Style changes for consistency with other JHU Libraries UX guidelines and/or recommendations
 
   - Header navigation bar:
-    - Contact Us link in upper right header (moved from footer b/c might be harder to notice on long pages)
     - Removed "Accessions", "Classifications", and "Digital Objects" links.
 
   - Footer:
@@ -26,18 +25,13 @@ user interface (PUI).
 - Since DOs link is gone, added some text and links to get visitors to some of
 other key repositories (JScholarship, Levy, and JHU Data Archive).
 
-### Record view:
-- Left-hand in-page anchor navigation: Changed "Components" to "Collection Details"
-- Changed "Components" section heading text to "Collection Details"
-- Changed Component tabs, when visible, to "Collection Details" and "Search this Collection".
-
 ### Breadcrumb:
 - Prefixed resource titles with call number/identifier.
+- Icons for record types.
 
 ### Search results:
 - Added callno/identifier column to results
 - Added column headings, since there are now two columns in the results
-- Added responsive "show/hide facets/filters" to make usable on mobile devices
 
 ---
 

--- a/public/views/layout_head.html.erb
+++ b/public/views/layout_head.html.erb
@@ -1,7 +1,261 @@
 <!--
 <link href="/assets/stylesheets/theme-bootstrap.css" rel="stylesheet" />
 <link href="/assets/stylesheets/theme-application.css" rel="stylesheet" />
--->
+
 <link href="/assets/stylesheets/jhu_fonts.css" rel="stylesheet" />
 <link href="/assets/stylesheets/jhu_public_theme.css" rel="stylesheet" />
+ <%= stylesheet_link_tag "/assets/stylesheets/jhu_fonts", media: 'all' %>
+-->
+ <%= stylesheet_link_tag "/assets/stylesheets/jhu_public_theme", media: 'all' %>
+
+<%# todo: loading fonts here, because we can't use asset_path() from CSS file %>
+<style>
+/*////////////////////////////////////////////////////////////////////////////*/
+/*/// GENTONA ////////////////////////////////////////////////////////////////*/
+/*////////////////////////////////////////////////////////////////////////////*/
+
+/*===================*/
+/*=== Heavy (900) ===*/
+/*===================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Heavy.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Heavy.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Heavy.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Heavy.ttf') %>') format('truetype');
+  font-weight: 900;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-HeavyItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-HeavyItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-HeavyItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-HeavyItalic.ttf') %>') format('truetype');
+  font-weight: 900;
+  font-style: italic;
+}
+
+/*========================*/
+/*=== Extra Bold (800) ===*/
+/*========================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraBold.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraBold.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraBold.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraBold.ttf') %>') format('truetype');
+  font-weight: 800;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraBoldItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraBoldItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraBoldItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraBoldItalic.ttf') %>') format('truetype');
+  font-weight: 800;
+  font-style: italic;
+}
+
+/*==================*/
+/*=== Bold (700) ===*/
+/*==================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Bold.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Bold.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Bold.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Bold.ttf') %>') format('truetype');
+  font-weight: 700;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-BoldItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-BoldItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-BoldItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-BoldItalic.ttf') %>') format('truetype');
+  font-weight: 700;
+  font-style: italic;
+}
+
+/*======================*/
+/*=== Semi-Bold (600) ===*/
+/*======================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-SemiBold.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-SemiBold.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-SemiBold.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-SemiBold.ttf') %>') format('truetype');
+  font-weight: 600;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-SemiBoldItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-SemiBoldItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-SemiBoldItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-SemiBoldItalic.ttf') %>') format('truetype');
+  font-weight: 600;
+  font-style: italic;
+}
+
+/*====================*/
+/*=== Medium (500) ===*/
+/*====================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Medium.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Medium.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Medium.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Medium.ttf') %>') format('truetype');
+  font-weight: 500;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-MediumItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-MediumItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-MediumItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-MediumItalic.ttf') %>') format('truetype');
+  font-weight: 500;
+  font-style: italic;
+}
+
+/*==================*/
+/*=== Book (400) ===*/
+/*==================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Book.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Book.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Book.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Book.ttf') %>') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-BookItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-BookItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-BookItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-BookItalic.ttf') %>') format('truetype');
+  font-weight: 400;
+  font-style: italic;
+}
+
+/*===================*/
+/*=== Light (300) ===*/
+/*===================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Light.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Light.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Light.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Light.ttf') %>') format('truetype');
+  font-weight: 300;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-LightItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-LightItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-LightItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-LightItalic.ttf') %>') format('truetype');
+  font-weight: 300;
+  font-style: italic;
+}
+
+/*=========================*/
+/*=== Extra Light (200) ===*/
+/*=========================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraLight.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraLight.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraLight.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraLight.ttf') %>') format('truetype');
+  font-weight: 200;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraLightItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraLightItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraLightItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ExtraLightItalic.ttf') %>') format('truetype');
+  font-weight: 200;
+  font-style: italic;
+}
+
+/*==================*/
+/*=== Thin (100) ===*/
+/*==================*/
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Thin.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Thin.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Thin.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-Thin.ttf') %>') format('truetype');
+  font-weight: 100;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'gentona';
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ThinItalic.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ThinItalic.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ThinItalic.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/gentona/webfonts/Gentona-ThinItalic.ttf') %>') format('truetype');
+  font-weight: 100;
+  font-style: italic;
+}
+
+/*////////////////////////////////////////////////////////////////////////////*/
+/*/// TITLING GOTHIC /////////////////////////////////////////////////////////*/
+/*////////////////////////////////////////////////////////////////////////////*/
+
+/*==================*/
+/*=== Bold (700) ===*/
+/*==================*/
+@font-face {
+  font-family: 'titling-gothic';
+  src: url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Bold.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Bold.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Bold.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Bold.ttf') %>') format('truetype'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Bold.svg#titlinggothicbold') %>') format('svg');
+  font-weight: 700;
+  font-style: normal;
+}
+
+/*====================*/
+/*=== Medium (500) ===*/
+/*====================*/
+@font-face {
+  font-family: 'titling-gothic';
+  src: url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Medium.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Medium.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Medium.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Medium.ttf') %>') format('truetype'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Medium.svg#titlinggothicmedium') %>') format('svg');
+  font-weight: 500;
+  font-style: normal;
+}
+
+/*=====================*/
+/*=== Regular (300) ===*/
+/*=====================*/
+@font-face {
+  font-family: 'titling-gothic';
+  src: url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Regular.eot') %>');
+  src: url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Regular.eot?#iefix') %>') format('embedded-opentype'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Regular.woff') %>') format('woff'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Regular.ttf') %>') format('truetype'),
+  url('<%= asset_path('/assets/fonts/Web/titling-gothic/webfonts/Titling-Gothic-Regular.svg#titlinggothicregular') %>') format('svg');
+  font-weight: 300;
+  font-style: normal;
+}
+</style>
 

--- a/public/views/shared/_branding.html.erb
+++ b/public/views/shared/_branding.html.erb
@@ -31,8 +31,7 @@
 <!-- site branding -->
 <div class="container-fluid">
   <div class="site-branding-org">
-    <%#= image_tag "images/libraries.logo.small.horizontal.blue.png", :alt => I18n.t("brand.title") %>
-    <img src="/assets/images/libraries.logo.small.horizontal.blue.png" alt="Johns Hopkins University logo">
+    <%= image_tag image_path("/assets/images/libraries.logo.small.horizontal.blue.png"), alt: "Johns Hopkins University logo" %>
   </div>
   <div class="site-branding-app">
     <%#= image_tag "archivesspace/archivesspace.png", :alt => I18n.t("brand.title") %>


### PR DESCRIPTION
Changes in layout and image, CSS, Javascript, and font asset configuration needed to make our implementation prefix aware for HTTPS reverse proxy.

Update README.md, which was very out of date.